### PR TITLE
allow publisher to create exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The goal with `go-rabbitmq` is to still provide most all of the nitty-gritty fun
 Outside of a Go module:
 
 ```bash
-go get github.com/wagslane/go-rabbitmq
+go get github.com/omni3x/go-rabbitmq
 ```
 
 ## 🚀 Quick Start Consumer

--- a/consume.go
+++ b/consume.go
@@ -205,7 +205,7 @@ func (consumer Consumer) startGoroutines(
 			return fmt.Errorf("binding to exchange but name not specified")
 		}
 		if exchange.Declare {
-			err = consumer.chManager.channel.ExchangeDeclare(
+			if err = consumer.chManager.channel.ExchangeDeclare(
 				exchange.Name,
 				exchange.Kind,
 				exchange.Durable,
@@ -213,11 +213,9 @@ func (consumer Consumer) startGoroutines(
 				exchange.Internal,
 				exchange.NoWait,
 				tableToAMQPTable(exchange.ExchangeArgs),
-			)
-		}
-
-		if err != nil {
-			return err
+			); err != nil {
+				return err
+			}
 		}
 
 		for _, routingKey := range routingKeys {

--- a/consume.go
+++ b/consume.go
@@ -199,8 +199,8 @@ func (consumer Consumer) startGoroutines(
 		return err
 	}
 
-	if consumeOptions.BindingExchange != nil {
-		exchange := consumeOptions.BindingExchange
+	if consumeOptions.ExchangeOptions != nil {
+		exchange := consumeOptions.ExchangeOptions
 		if exchange.Name == "" {
 			return fmt.Errorf("binding to exchange but name not specified")
 		}
@@ -214,10 +214,12 @@ func (consumer Consumer) startGoroutines(
 				exchange.NoWait,
 				tableToAMQPTable(exchange.ExchangeArgs),
 			)
-			if err != nil {
-				return err
-			}
 		}
+
+		if err != nil {
+			return err
+		}
+
 		for _, routingKey := range routingKeys {
 			err = consumer.chManager.channel.QueueBind(
 				queue,

--- a/consume_options.go
+++ b/consume_options.go
@@ -8,9 +8,9 @@ func getDefaultConsumeOptions() ConsumeOptions {
 		QueueExclusive:    false,
 		QueueNoWait:       false,
 		QueueArgs:         nil,
-		BindingExchange:   nil,
 		BindingNoWait:     false,
 		BindingArgs:       nil,
+		ExchangeOptions:   nil,
 		Concurrency:       1,
 		QOSPrefetch:       0,
 		QOSGlobal:         false,
@@ -30,10 +30,10 @@ type ConsumeOptions struct {
 	QueueExclusive    bool
 	QueueNoWait       bool
 	QueueArgs         Table
-	BindingExchange   *BindingExchangeOptions
 	BindingNoWait     bool
 	BindingArgs       Table
 	Concurrency       int
+	ExchangeOptions   *ExchangeOptions
 	QOSPrefetch       int
 	QOSGlobal         bool
 	ConsumerName      string
@@ -42,36 +42,6 @@ type ConsumeOptions struct {
 	ConsumerNoWait    bool
 	ConsumerNoLocal   bool
 	ConsumerArgs      Table
-}
-
-// getBindingExchangeOptionsOrSetDefault returns pointer to current BindingExchange options. if no BindingExchange options are set yet, it will set it with default values.
-func getBindingExchangeOptionsOrSetDefault(options *ConsumeOptions) *BindingExchangeOptions {
-	if options.BindingExchange == nil {
-		options.BindingExchange = &BindingExchangeOptions{
-			Name:         "",
-			Kind:         "direct",
-			Durable:      false,
-			AutoDelete:   false,
-			Internal:     false,
-			NoWait:       false,
-			ExchangeArgs: nil,
-			Declare:      true,
-		}
-	}
-	return options.BindingExchange
-}
-
-// BindingExchangeOptions are used when binding to an exchange.
-// it will verify the exchange is created before binding to it.
-type BindingExchangeOptions struct {
-	Name         string
-	Kind         string
-	Durable      bool
-	AutoDelete   bool
-	Internal     bool
-	NoWait       bool
-	ExchangeArgs Table
-	Declare      bool
 }
 
 // WithConsumeOptionsQueueDurable sets the queue to durable, which means it won't
@@ -115,49 +85,48 @@ func WithConsumeOptionsQuorum(options *ConsumeOptions) {
 // WithConsumeOptionsBindingExchangeName returns a function that sets the exchange name the queue will be bound to
 func WithConsumeOptionsBindingExchangeName(name string) func(*ConsumeOptions) {
 	return func(options *ConsumeOptions) {
-		getBindingExchangeOptionsOrSetDefault(options).Name = name
+		getConsumerExchangeOptionsOrSetDefault(options).Name = name
 	}
 }
 
 // WithConsumeOptionsBindingExchangeKind returns a function that sets the binding exchange kind/type
 func WithConsumeOptionsBindingExchangeKind(kind string) func(*ConsumeOptions) {
 	return func(options *ConsumeOptions) {
-		getBindingExchangeOptionsOrSetDefault(options).Kind = kind
+		getConsumerExchangeOptionsOrSetDefault(options).Kind = kind
 	}
 }
 
 // WithConsumeOptionsBindingExchangeDurable returns a function that sets the binding exchange durable flag
 func WithConsumeOptionsBindingExchangeDurable(options *ConsumeOptions) {
-	getBindingExchangeOptionsOrSetDefault(options).Durable = true
+	getConsumerExchangeOptionsOrSetDefault(options).Durable = true
 }
 
 // WithConsumeOptionsBindingExchangeAutoDelete returns a function that sets the binding exchange autoDelete flag
 func WithConsumeOptionsBindingExchangeAutoDelete(options *ConsumeOptions) {
-	getBindingExchangeOptionsOrSetDefault(options).AutoDelete = true
+	getConsumerExchangeOptionsOrSetDefault(options).AutoDelete = true
 }
 
 // WithConsumeOptionsBindingExchangeInternal returns a function that sets the binding exchange internal flag
 func WithConsumeOptionsBindingExchangeInternal(options *ConsumeOptions) {
-	getBindingExchangeOptionsOrSetDefault(options).Internal = true
+	getConsumerExchangeOptionsOrSetDefault(options).Internal = true
 }
 
 // WithConsumeOptionsBindingExchangeNoWait returns a function that sets the binding exchange noWait flag
 func WithConsumeOptionsBindingExchangeNoWait(options *ConsumeOptions) {
-	getBindingExchangeOptionsOrSetDefault(options).NoWait = true
+	getConsumerExchangeOptionsOrSetDefault(options).NoWait = true
 }
 
 // WithConsumeOptionsBindingExchangeArgs returns a function that sets the binding exchange arguments that are specific to the server's implementation of the exchange
 func WithConsumeOptionsBindingExchangeArgs(args Table) func(*ConsumeOptions) {
 	return func(options *ConsumeOptions) {
-		getBindingExchangeOptionsOrSetDefault(options).ExchangeArgs = args
+		getConsumerExchangeOptionsOrSetDefault(options).ExchangeArgs = args
 	}
 }
 
-// WithConsumeOptionsBindingExchangeSkipDeclare returns a function that skips the declaration of the
-// binding exchange. Use this setting if the exchange already exists and you don't need to declare
-// it on consumer start.
-func WithConsumeOptionsBindingExchangeSkipDeclare(options *ConsumeOptions) {
-	getBindingExchangeOptionsOrSetDefault(options).Declare = false
+// WithConsumeOptionsBindingExchangeDeclare returns a function that declares the binding exchange.
+// Use this setting if you want the consumer to create the exchange on start.
+func WithConsumeOptionsBindingExchangeDeclare(options *ConsumeOptions) {
+	getConsumerExchangeOptionsOrSetDefault(options).Declare = true
 }
 
 // WithConsumeOptionsBindingNoWait sets the bindings to nowait, which means if the queue can not be bound

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	rabbitmq "github.com/omni3x/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 func main() {

--- a/examples/logger/main.go
+++ b/examples/logger/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	rabbitmq "github.com/omni3x/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 // customLogger is used in WithPublisherOptionsLogger to create a custom logger.

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 
+	rabbitmq "github.com/omni3x/go-rabbitmq"
 	amqp "github.com/rabbitmq/amqp091-go"
-	rabbitmq "github.com/wagslane/go-rabbitmq"
 )
 
 func main() {

--- a/exchange.go
+++ b/exchange.go
@@ -1,0 +1,48 @@
+package rabbitmq
+
+// ExchangeOptions are used when configuring or binding to an exchange.
+// it will verify the exchange is created before binding to it.
+type ExchangeOptions struct {
+	Name         string
+	Kind         string
+	Durable      bool
+	AutoDelete   bool
+	Internal     bool
+	NoWait       bool
+	ExchangeArgs Table
+	Declare      bool
+}
+
+// getConsumerExchangeOptionsOrSetDefault returns pointer to current Exchange options. if no Exchange options are set yet, it will set it with default values.
+func getConsumerExchangeOptionsOrSetDefault(options *ConsumeOptions) *ExchangeOptions {
+	if options.ExchangeOptions == nil {
+		options.ExchangeOptions = &ExchangeOptions{
+			Name:         "",
+			Kind:         "direct",
+			Durable:      false,
+			AutoDelete:   false,
+			Internal:     false,
+			NoWait:       false,
+			ExchangeArgs: nil,
+			Declare:      false,
+		}
+	}
+	return options.ExchangeOptions
+}
+
+// getPublisherExchangeOptionsOrSetDefault returns pointer to current Exchange options. if no Exchange options are set yet, it will set it with default values.
+func getPublisherExchangeOptionsOrSetDefault(options *PublisherOptions) *ExchangeOptions {
+	if options.ExchangeOptions == nil {
+		options.ExchangeOptions = &ExchangeOptions{
+			Name:         "",
+			Kind:         "direct",
+			Durable:      false,
+			AutoDelete:   false,
+			Internal:     false,
+			NoWait:       false,
+			ExchangeArgs: nil,
+			Declare:      true,
+		}
+	}
+	return options.ExchangeOptions
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/wagslane/go-rabbitmq
+module github.com/omni3x/go-rabbitmq
 
 go 1.16
 

--- a/publish_options.go
+++ b/publish_options.go
@@ -1,0 +1,71 @@
+package rabbitmq
+
+func getDefaultPublishOptions() PublishOptions {
+	return PublishOptions{
+		Mandatory:    false,
+		Immediate:    false,
+		ContentType:  "",
+		DeliveryMode: Transient,
+		Expiration:   "",
+		Headers:      nil,
+	}
+}
+
+// PublishOptions are used to control how data is published
+type PublishOptions struct {
+	// Mandatory fails to publish if there are no queues
+	// bound to the routing key
+	Mandatory bool
+	// Immediate fails to publish if there are no consumers
+	// that can ack bound to the queue on the routing key
+	Immediate   bool
+	ContentType string
+	// Transient or Persistent
+	DeliveryMode uint8
+	// Expiration time in ms that a message will expire from a queue.
+	// See https://www.rabbitmq.com/ttl.html#per-message-ttl-in-publishers
+	Expiration string
+	Headers    Table
+}
+
+// WithPublishOptionsMandatory makes the publishing mandatory, which means when a queue is not
+// bound to the routing key a message will be sent back on the returns channel for you to handle
+func WithPublishOptionsMandatory(options *PublishOptions) {
+	options.Mandatory = true
+}
+
+// WithPublishOptionsImmediate makes the publishing immediate, which means when a consumer is not available
+// to immediately handle the new message, a message will be sent back on the returns channel for you to handle
+func WithPublishOptionsImmediate(options *PublishOptions) {
+	options.Immediate = true
+}
+
+// WithPublishOptionsContentType returns a function that sets the content type, i.e. "application/json"
+func WithPublishOptionsContentType(contentType string) func(*PublishOptions) {
+	return func(options *PublishOptions) {
+		options.ContentType = contentType
+	}
+}
+
+// WithPublishOptionsPersistentDelivery sets the message to persist. Transient messages will
+// not be restored to durable queues, persistent messages will be restored to
+// durable queues and lost on non-durable queues during server restart. By default publishings
+// are transient
+func WithPublishOptionsPersistentDelivery(options *PublishOptions) {
+	options.DeliveryMode = Persistent
+}
+
+// WithPublishOptionsExpiration returns a function that sets the expiry/TTL of a message. As per RabbitMq spec, it must be a
+// string value in milliseconds.
+func WithPublishOptionsExpiration(expiration string) func(options *PublishOptions) {
+	return func(options *PublishOptions) {
+		options.Expiration = expiration
+	}
+}
+
+// WithPublishOptionsHeaders returns a function that sets message header values, i.e. "msg-id"
+func WithPublishOptionsHeaders(headers Table) func(*PublishOptions) {
+	return func(options *PublishOptions) {
+		options.Headers = headers
+	}
+}


### PR DESCRIPTION
## Summary

there's an existing repo `wagslane/go-rabbitmq` which builds on top of rabbitmq's AMQP repository. it adds some convenient features such as:
- automatically reconnecting if a connection is dropped
- methods to standardize how consumers/publishers connect to queues and exchanges

high level flow of RabbitMQ:
PUBLISHERS -> publish to EXCHANGES
EXCHANGES -> 1...n bindings to QUEUES
QUEUES -> consumers subscribe to queues to get messages

where the `wagslane/go-rabbitmq` repo falls short is that it has the consumers driving the creation of both queues and exchanges, which ends up tightly coupling publishers and consumers together

this change allows a user to have the publisher create the exchanges in addition to additional configuration such as durability